### PR TITLE
Replace a windows build directive accidentally removed

### DIFF
--- a/mutex_flock.go
+++ b/mutex_flock.go
@@ -2,6 +2,7 @@
 // Licensed under the LGPLv3, see LICENCE file for details.
 
 //go:build !windows
+// +build !windows
 
 package mutex
 


### PR DESCRIPTION
Add back an accidentally removed build directive for windows.