### PR TITLE
Allow arbitrary names

### DIFF
--- a/mutex_flock.go
+++ b/mutex_flock.go
@@ -21,7 +21,7 @@ func acquire(spec Spec, timeout <-chan time.Time) (Releaser, error) {
 	done := make(chan struct{})
 	defer close(done)
 	select {
-	case result := <-acquireFlock(spec.Name, done):
+	case result := <-acquireFlock(spec.GetMutexName(), done):
 		if result.err != nil {
 			return nil, errors.Trace(result.err)
 		}
@@ -178,6 +178,7 @@ func (m *mutex) Release() {
 
 // Environment defines a simple interface with interacting with environmental
 // variables.
+//
 //go:generate mockgen -package mutex_test -destination mutex_mock_test.go github.com/juju/mutex Environment
 type Environment interface {
 

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -42,20 +42,15 @@ func (s *mutexSuite) TestSpecValidity(c *gc.C) {
 		err  string
 	}{{
 		spec: mutex.Spec{Name: "", Clock: &fakeClock{}, Delay: time.Millisecond},
-		err:  `Name "" not valid`,
-	}, {
-		spec: mutex.Spec{Name: "42", Clock: &fakeClock{}, Delay: time.Millisecond},
-		err:  `Name "42" not valid`,
+		err:  `missing Name not valid`,
 	}, {
 		spec: mutex.Spec{Name: "a", Clock: &fakeClock{}, Delay: time.Millisecond},
 	}, {
-		spec: mutex.Spec{Name: "a very very long name that is over the length limit", Clock: &fakeClock{}, Delay: time.Millisecond},
-		err:  `Name longer than 40 characters not valid`,
+		spec: mutex.Spec{Name: "a very very long name", Clock: &fakeClock{}, Delay: time.Millisecond},
 	}, {
-		spec: mutex.Spec{Name: "test-42", Clock: &fakeClock{}, Delay: time.Millisecond},
+		spec: mutex.Spec{Name: "a-name-with-dashes", Clock: &fakeClock{}, Delay: time.Millisecond},
 	}, {
-		spec: mutex.Spec{Name: "with a space", Clock: &fakeClock{}, Delay: time.Millisecond},
-		err:  `Name "with a space" not valid`,
+		spec: mutex.Spec{Name: "a name with spaces", Clock: &fakeClock{}, Delay: time.Millisecond},
 	}, {
 		spec: mutex.Spec{Name: "test-42", Delay: time.Millisecond},
 		err:  `missing Clock not valid`,
@@ -297,7 +292,7 @@ func (s *mutexSuite) TestFilePermissions(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer r.Release()
 
-	filePath := filepath.Join(os.TempDir(), "juju-"+spec.Name)
+	filePath := filepath.Join(os.TempDir(), "juju-"+spec.GetMutexName())
 	fileInfo, err := os.Stat(filePath)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -334,7 +329,7 @@ func (s *mutexSuite) TestFilePermissionsWithSudoEnvars(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer r.Release()
 
-	filePath := filepath.Join(os.TempDir(), "juju-"+spec.Name)
+	filePath := filepath.Join(os.TempDir(), "juju-"+spec.GetMutexName())
 	fileInfo, err := os.Stat(filePath)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/mutex_windows.go
+++ b/mutex_windows.go
@@ -48,7 +48,7 @@ func acquire(spec Spec, timeoutCh <-chan time.Time) (Releaser, error) {
 	}
 
 	m := &mutex{
-		name:     spec.Name,
+		name:     spec.GetMutexName(),
 		release:  make(chan struct{}),
 		released: make(chan struct{}),
 	}


### PR DESCRIPTION
This PR aims to fix https://github.com/juju/mutex/issues/15. It moves restrictions to the actual implementation, so the caller does not have to deal with them.

In this case, the validations were about having "expected" strings (they have to match a pattern) and not being more than 40 chars long.

These restrictions can be bypassed by using a hash algorithm.

Hence, this PR re-implements the acquire logic to use the SHA1 checksum as the mutex name, which meets all the expectations.

**EDIT**: I first tried using the SHA1 algorithm. But the resulting checksum might start with a number. Is starting with a letter a mandatory constraint?

**EDIT 2**: I secondly tried using the MD5 algorithm. The resulting checksum is 32 chars long so it is OK, even though it might not start with a letter. I have added support for a prefix with a max length of 7 charts, starting with a letter. The default prefix will be `mutex`.

___

### Questions

#### Why the mutex name must start with a letter?

If this is not a constraint, we can use SHA1 algorithm for simplicity.

#### Why the mutex name max length must be 40 chart length?

If this is not a constraint, we can support using arbitrary prefixes regardless the hash algorithm used to compute the mutex name.